### PR TITLE
[Enhancement] JiraClient에 get_comments 메서드 추가

### DIFF
--- a/src/jira_mcp/config.py
+++ b/src/jira_mcp/config.py
@@ -19,4 +19,4 @@ class Settings(BaseSettings):
 
 def get_settings() -> Settings:
     """Get application settings."""
-    return Settings()
+    return Settings()  # type: ignore[call-arg]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 """Tests for Jira client module."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -22,9 +22,12 @@ async def test_get_issue(jira_client: JiraClient) -> None:
         "fields": {"summary": "Test issue"},
     }
 
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
     with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
-        mock_get.return_value.json.return_value = mock_response
-        mock_get.return_value.raise_for_status = lambda: None
+        mock_get.return_value = mock_response_obj
 
         result = await jira_client.get_issue("TEST-1")
 
@@ -39,9 +42,12 @@ async def test_search_issues(jira_client: JiraClient) -> None:
         "total": 2,
     }
 
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
     with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
-        mock_get.return_value.json.return_value = mock_response
-        mock_get.return_value.raise_for_status = lambda: None
+        mock_get.return_value = mock_response_obj
 
         result = await jira_client.search_issues("project = TEST")
 
@@ -53,9 +59,12 @@ async def test_create_issue(jira_client: JiraClient) -> None:
     """Test creating an issue."""
     mock_response = {"key": "TEST-3", "id": "10003"}
 
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
     with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.return_value.json.return_value = mock_response
-        mock_post.return_value.raise_for_status = lambda: None
+        mock_post.return_value = mock_response_obj
 
         result = await jira_client.create_issue(
             project_key="TEST",
@@ -64,3 +73,433 @@ async def test_create_issue(jira_client: JiraClient) -> None:
         )
 
         assert result["key"] == "TEST-3"
+
+
+@pytest.mark.asyncio
+async def test_get_comments_default_params(jira_client: JiraClient) -> None:
+    """Test getting comments with default pagination parameters."""
+    mock_response = {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": 3,
+        "isLast": True,
+        "values": [
+            {
+                "id": "10001",
+                "author": {
+                    "displayName": "John Doe",
+                    "emailAddress": "john@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "First comment"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T10:00:00.000+0000",
+                "updated": "2024-01-15T10:00:00.000+0000"
+            },
+            {
+                "id": "10002",
+                "author": {
+                    "displayName": "Jane Smith",
+                    "emailAddress": "jane@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Second comment"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T11:00:00.000+0000",
+                "updated": "2024-01-15T11:00:00.000+0000"
+            },
+            {
+                "id": "10003",
+                "author": {
+                    "displayName": "Bob Johnson",
+                    "emailAddress": "bob@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Third comment"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T12:00:00.000+0000",
+                "updated": "2024-01-15T12:00:00.000+0000"
+            }
+        ]
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        result = await jira_client.get_comments("TEST-1")
+
+        assert result["total"] == 3
+        assert len(result["values"]) == 3
+        assert result["startAt"] == 0
+        assert result["maxResults"] == 50
+        assert result["isLast"] is True
+        assert result["values"][0]["id"] == "10001"
+        assert result["values"][1]["id"] == "10002"
+        assert result["values"][2]["id"] == "10003"
+
+        # Verify API call was made with correct parameters
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert call_args[0][0] == "https://test.atlassian.net/rest/api/3/issue/TEST-1/comment"
+        assert call_args[1]["params"]["startAt"] == 0
+        assert call_args[1]["params"]["maxResults"] == 50
+        assert call_args[1]["auth"] == ("test@example.com", "test-token")
+        assert call_args[1]["headers"]["Accept"] == "application/json"
+        assert call_args[1]["headers"]["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_get_comments_custom_pagination(jira_client: JiraClient) -> None:
+    """Test getting comments with custom pagination parameters."""
+    mock_response = {
+        "startAt": 10,
+        "maxResults": 20,
+        "total": 50,
+        "isLast": False,
+        "values": [
+            {
+                "id": "10011",
+                "author": {
+                    "displayName": "User Test",
+                    "emailAddress": "user@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Paginated comment"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T13:00:00.000+0000",
+                "updated": "2024-01-15T13:00:00.000+0000"
+            }
+        ]
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        result = await jira_client.get_comments("TEST-2", start_at=10, max_results=20)
+
+        assert result["startAt"] == 10
+        assert result["maxResults"] == 20
+        assert result["total"] == 50
+        assert result["isLast"] is False
+        assert len(result["values"]) == 1
+
+        # Verify custom pagination parameters were used
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert call_args[1]["params"]["startAt"] == 10
+        assert call_args[1]["params"]["maxResults"] == 20
+
+
+@pytest.mark.asyncio
+async def test_get_comments_empty_list(jira_client: JiraClient) -> None:
+    """Test getting comments when there are no comments."""
+    mock_response = {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": 0,
+        "isLast": True,
+        "values": []
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        result = await jira_client.get_comments("TEST-3")
+
+        assert result["total"] == 0
+        assert len(result["values"]) == 0
+        assert result["isLast"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_comments_single_comment(jira_client: JiraClient) -> None:
+    """Test getting a single comment."""
+    mock_response = {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": 1,
+        "isLast": True,
+        "values": [
+            {
+                "id": "10001",
+                "author": {
+                    "displayName": "Single User",
+                    "emailAddress": "single@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Only comment"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T10:00:00.000+0000",
+                "updated": "2024-01-15T10:00:00.000+0000"
+            }
+        ]
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        result = await jira_client.get_comments("TEST-4")
+
+        assert result["total"] == 1
+        assert len(result["values"]) == 1
+        assert result["values"][0]["id"] == "10001"
+
+
+@pytest.mark.asyncio
+async def test_get_comments_last_page(jira_client: JiraClient) -> None:
+    """Test getting the last page of comments."""
+    mock_response = {
+        "startAt": 40,
+        "maxResults": 50,
+        "total": 45,
+        "isLast": True,
+        "values": [
+            {
+                "id": "10041",
+                "author": {
+                    "displayName": "Last User",
+                    "emailAddress": "last@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Comment on last page"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T14:00:00.000+0000",
+                "updated": "2024-01-15T14:00:00.000+0000"
+            }
+        ]
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        result = await jira_client.get_comments("TEST-5", start_at=40)
+
+        assert result["isLast"] is True
+        assert result["startAt"] == 40
+        assert result["total"] == 45
+
+
+@pytest.mark.asyncio
+async def test_get_comments_complex_adf_body(jira_client: JiraClient) -> None:
+    """Test getting comments with complex ADF body structure."""
+    mock_response = {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": 1,
+        "isLast": True,
+        "values": [
+            {
+                "id": "10001",
+                "author": {
+                    "displayName": "Advanced User",
+                    "emailAddress": "advanced@example.com"
+                },
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "This is "
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "bold text",
+                                    "marks": [{"type": "strong"}]
+                                },
+                                {
+                                    "type": "text",
+                                    "text": " and "
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "italic text",
+                                    "marks": [{"type": "em"}]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "bulletList",
+                            "content": [
+                                {
+                                    "type": "listItem",
+                                    "content": [
+                                        {
+                                            "type": "paragraph",
+                                            "content": [
+                                                {
+                                                    "type": "text",
+                                                    "text": "First item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "listItem",
+                                    "content": [
+                                        {
+                                            "type": "paragraph",
+                                            "content": [
+                                                {
+                                                    "type": "text",
+                                                    "text": "Second item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "created": "2024-01-15T15:00:00.000+0000",
+                "updated": "2024-01-15T15:00:00.000+0000"
+            }
+        ]
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        result = await jira_client.get_comments("TEST-6")
+
+        assert result["total"] == 1
+        assert len(result["values"]) == 1
+        comment = result["values"][0]
+        assert comment["body"]["type"] == "doc"
+        assert len(comment["body"]["content"]) == 2
+        assert comment["body"]["content"][0]["type"] == "paragraph"
+        assert comment["body"]["content"][1]["type"] == "bulletList"
+
+
+@pytest.mark.asyncio
+async def test_get_comments_url_construction(jira_client: JiraClient) -> None:
+    """Test that get_comments constructs the correct URL for different issue keys."""
+    mock_response = {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": 0,
+        "isLast": True,
+        "values": []
+    }
+
+    mock_response_obj = Mock()
+    mock_response_obj.json.return_value = mock_response
+    mock_response_obj.raise_for_status = Mock()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response_obj
+
+        # Test with different issue key formats
+        issue_keys = ["PROJ-123", "TEST-1", "ABC-9999"]
+
+        for issue_key in issue_keys:
+            await jira_client.get_comments(issue_key)
+
+        # Verify all calls were made with correct URLs
+        assert mock_get.call_count == 3
+        calls = mock_get.call_args_list
+
+        assert calls[0][0][0] == "https://test.atlassian.net/rest/api/3/issue/PROJ-123/comment"
+        assert calls[1][0][0] == "https://test.atlassian.net/rest/api/3/issue/TEST-1/comment"
+        assert calls[2][0][0] == "https://test.atlassian.net/rest/api/3/issue/ABC-9999/comment"


### PR DESCRIPTION
## Summary

이슈 #1을 해결하기 위해 JiraClient 클래스에 특정 이슈의 코멘트 리스트를 가져오는 `get_comments` 메서드를 추가했습니다.

### 주요 변경사항

- **get_comments 메서드 구현** ([client.py:107-134](https://github.com/sirius2k/jira_mcp/blob/issue-1/src/jira_mcp/client.py#L107-L134))
  - Jira REST API v3 `/rest/api/3/issue/{issueIdOrKey}/comment` 엔드포인트 활용
  - 페이지네이션 지원: `startAt` (기본값: 0), `maxResults` (기본값: 50) 파라미터
  - ADF (Atlassian Document Format) 형식의 코멘트 body 반환
  - 응답 포함: `startAt`, `maxResults`, `total`, `isLast`, `values` 필드

- **포괄적인 테스트 작성** (7개 테스트 추가)
  - ✓ 기본 파라미터로 코멘트 조회
  - ✓ 커스텀 페이지네이션 파라미터 검증
  - ✓ 빈 코멘트 리스트 처리
  - ✓ 단일 코멘트 처리
  - ✓ 마지막 페이지 시나리오
  - ✓ 복잡한 ADF body 구조 처리
  - ✓ URL 구성 검증
  - 80% 이상의 코드 커버리지 달성

- **타입 안정성 개선**
  - 모든 메서드에 `cast()` 적용하여 mypy strict 모드 통과
  - 정확한 타입 힌팅: `dict[str, Any]` 반환

- **코드 품질 개선**
  - ruff 린팅 규칙 준수 (E501 line length 등)
  - 코드 포맷팅 일관성 유지

## 구현 세부사항

### API 호출 예시

```python
# 기본 사용 (첫 50개 코멘트)
comments = await jira_client.get_comments("PROJ-123")

# 페이지네이션 사용
comments = await jira_client.get_comments("PROJ-123", start_at=10, max_results=20)
```

### 응답 구조

```json
{
  "startAt": 0,
  "maxResults": 50,
  "total": 100,
  "isLast": false,
  "values": [
    {
      "id": "10000",
      "body": {...},
      "author": {...},
      "created": "2025-01-20T00:00:00.000+0000",
      "updated": "2025-01-20T00:00:00.000+0000"
    }
  ]
}
```

## 테스트 결과

### 전체 테스트 통과: 14/14 ✓

```
tests/test_client.py::test_get_issue PASSED
tests/test_client.py::test_search_issues PASSED
tests/test_client.py::test_create_issue PASSED
tests/test_client.py::test_get_comments_default_params PASSED
tests/test_client.py::test_get_comments_custom_pagination PASSED
tests/test_client.py::test_get_comments_empty_list PASSED
tests/test_client.py::test_get_comments_single_comment PASSED
tests/test_client.py::test_get_comments_last_page PASSED
tests/test_client.py::test_get_comments_complex_adf_body PASSED
tests/test_client.py::test_get_comments_url_construction PASSED
tests/test_config.py::test_settings_from_env PASSED
tests/test_config.py::test_settings_custom_timeout PASSED
tests/test_server.py::test_list_tools PASSED
tests/test_server.py::test_tool_schemas PASSED
```

### 코드 품질 검증

- ✓ **pytest**: 모든 테스트 통과 (0.27초)
- ✓ **ruff check**: 린팅 이슈 없음
- ✓ **ruff format**: 코드 포맷팅 완료
- ✓ **mypy**: 타입 체킹 통과 (strict 모드)

## 관련 이슈

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)